### PR TITLE
Use abbreviated month name in tell output, to be less ambiguous.

### DIFF
--- a/tell.py
+++ b/tell.py
@@ -100,7 +100,7 @@ def checktell(phenny, input):
 			continue
 		phenny.say("%s: %s <%s> %s" % (
 			input.nick,
-			time.strftime('%m-%d %H:%M UTC', time.gmtime(e[4])),
+			time.strftime('%b-%d %H:%M UTC', time.gmtime(e[4])),
 			e[1],
 			e[3]))
 		r.append(e[0])


### PR DESCRIPTION
Tell output from the bot includes a datestamp which is ambiguous: it is actually month-day, but "10-11" could just as easily be November 10th as October 11th.  This change is to use the abbreviated month name instead.  An alternative would be to go full ISO8601 and include the year as well, but I figured that might be a little verbose.